### PR TITLE
Add skip method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ As of v0.3.1, full forms of dot notation are supported in keys, by way of [dot-n
 
 Static is basically the same as just calling `it` over and over again with different values in the closure. This provides an easy shorthand to create tests from existing values. The signature of static titling is the same as that of dynamic, except with the omission of the `fields` parameter.
 
+**Skip**
+
+When developing a test it is sometimes useful to be able to skip all other tests in the suite. This may be done by using `it.each.skip`.
+
 ### Context ###
 
 As of version v0.3.0 the context of the `it` is provided to the executed function in order to allow setting both `slow` and `timeout` from within the executed function. This is a potentially breaking change, however I doubt anybody was using `this` in the current version since it provided no additional context.

--- a/lib/it.each.js
+++ b/lib/it.each.js
@@ -75,4 +75,8 @@ module.exports = function(opts) {
 
     };
 
+    it.each.skip = function (iterator, title, fields, process) {
+        it.skip(title);
+    }
+
 };

--- a/test/it.each.js
+++ b/test/it.each.js
@@ -185,7 +185,5 @@ describe('it.each with testPerIteration: false', function(){
             this._runnable.title.should.be.ok;
             this._runnable.title.should.endWith('- ' + element + '/2');
         });
-
     });
-
 });

--- a/test/it.each.skip.js
+++ b/test/it.each.skip.js
@@ -1,0 +1,65 @@
+require('should');
+
+describe('it.each.skip test suite', function(){
+
+    require('../index')();
+
+    describe('it.each.skip tests', function() {
+        const numbers = [1, 2, 3, 4];
+        after(function() {
+            var isPending = 0;
+            var isExecuted = 0;
+            var tests = this.test.parent.tests;
+            for (var i=0; i < tests.length; i += 1) {
+                (tests[i].pending === true) ? isPending +=1 : isExecuted += 1;
+            }
+            isPending.should.eql(3);
+            isExecuted.should.eql(1);
+        });
+
+        it.each(numbers, 'Assert %s is less than 5', ['element'], function(element) {
+            element.should.be.below(5);
+        });
+
+        it.each.skip(numbers, 'Assert %s is less than 5', ['element'], function(element) {
+            element.should.be.below(5);
+        });
+
+        it.each.skip([{ field: 1 }], 'should contain object values: %s', ['field'], function(/* element */){
+            this._runnable.should.be.ok;
+            this._runnable.title.should.be.ok;
+            this._runnable.title.should.endWith('1');
+        });
+
+        it.each.skip([1,2], 'should contain iteration markers', function(element){
+            this._runnable.should.be.ok;
+            this._runnable.title.should.be.ok;
+            this._runnable.title.should.endWith('- ' + element + '/2');
+        });
+    });
+
+    describe('it.each.skip testPerIteration tests', function() {
+        require('../index')({
+            testPerIteration: true
+        });
+        const numbers = [1, 2, 3, 4, 5, 6, 7, 8];
+        after(function() {
+            var isPending = 0;
+            var isExecuted = 0;
+            var tests = this.test.parent.tests;
+            for (var i=0; i < tests.length; i += 1) {
+                (tests[i].pending === true) ? isPending +=1 : isExecuted += 1;
+            }
+            isPending.should.eql(1);
+            isExecuted.should.eql(8);
+        });
+
+        it.each(numbers, 'Assert %s is less than 5', ['element'], function(element) {
+            element.should.be.below(9);
+        });
+
+        it.each.skip(numbers, 'Assert %s is less than 5', ['element'], function(element) {
+            element.should.be.below(9);
+        });
+    });
+});


### PR DESCRIPTION
**Change log**

1. lib/it.each.js
Added the `it.each.skip` function which will allow you to skip a test that uses `it.each`.

2. test/it.each.js
Added test suite for the new it.each.skip function that skips 3 tests, runs 1. Then the count from the test suite is then verified.

**Verification**
```
npm run test
```